### PR TITLE
fix init command

### DIFF
--- a/lib/vgcal/handlers/describer.rb
+++ b/lib/vgcal/handlers/describer.rb
@@ -15,9 +15,10 @@ module Vgcal
         vgcal_dir = "#{Dir.home}/.vgcal"
         cred_json = "#{vgcal_dir}/credentials.json"
         dot_env   = "#{vgcal_dir}/.env"
+        gem_root  = File.expand_path '../../../', __dir__
         Dir.mkdir(vgcal_dir, 0o755) unless Dir.exist?(vgcal_dir)
-        FileUtils.cp('template-credentials.json', cred_json) unless File.exist?(cred_json)
-        FileUtils.cp('template.env', dot_env) unless File.exist?(dot_env)
+        FileUtils.cp(File.join(gem_root,'template-credentials.json'), cred_json) unless File.exist?(cred_json)
+        FileUtils.cp(File.join(gem_root,'template.env'), dot_env) unless File.exist?(dot_env)
         puts "Fix the __FIX_ME__ in #{cred_json} and #{dot_env}"
       end
 


### PR DESCRIPTION
It's couldn't access the template file, so I fixed it.

```
root@ce65675642c7:/# vgcal init
/usr/local/lib/ruby/3.0.0/fileutils.rb:1414:in `initialize': No such file or directory @ rb_sysopen - template-credentials.json (Errno::ENOENT)
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:1414:in `open'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:1414:in `copy_file'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:514:in `copy_file'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:433:in `block in cp'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:1597:in `block in fu_each_src_dest'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:1613:in `fu_each_src_dest0'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:1595:in `fu_each_src_dest'
        from /usr/local/lib/ruby/3.0.0/fileutils.rb:432:in `cp'
        from /usr/local/bundle/gems/vgcal-0.3.2/lib/vgcal/handlers/describer.rb:19:in `init'
        from /usr/local/bundle/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
        from /usr/local/bundle/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
        from /usr/local/bundle/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
        from /usr/local/bundle/gems/thor-1.1.0/lib/thor/base.rb:485:in `start'
        from /usr/local/bundle/gems/vgcal-0.3.2/lib/vgcal/handlers/describer.rb:168:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/usr/local/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /usr/local/bundle/gems/vgcal-0.3.2/lib/vgcal.rb:8:in `<module:Vgcal>'
        from /usr/local/bundle/gems/vgcal-0.3.2/lib/vgcal.rb:6:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/usr/local/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from /usr/local/bundle/gems/vgcal-0.3.2/exe/vgcal:3:in `<top (required)>'
        from /usr/local/bundle/bin/vgcal:23:in `load'
        from /usr/local/bundle/bin/vgcal:23:in `<main>'
```

```
root@ce65675642c7:/# vgcal init
Fix the __FIX_ME__ in /root/.vgcal/credentials.json and /root/.vgcal/.env
```